### PR TITLE
Skip title search for URLs to accelerate bulk import process

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -236,7 +236,7 @@ function yourls_add_new_link( $url, $keyword = '', $title = '' ) {
 		if( isset( $title ) && !empty( $title ) ) {
 			$title = yourls_sanitize_title( $title );
 		} else {
-			$title = yourls_get_remote_title( $url );
+			$title = $url;
 		}
 		$title = yourls_apply_filter( 'add_new_title', $title, $url, $keyword );
 


### PR DESCRIPTION
To accelerate bulk import process, we use the long url as the title which reduce the overall time significantly. Further tested on 12,000+ bulk import urls works perfectly in less than 2 minutes.